### PR TITLE
Allow size to be optionally passed to package discovery

### DIFF
--- a/package_review/management/commands/discover_packages.py
+++ b/package_review/management/commands/discover_packages.py
@@ -21,6 +21,7 @@ class Command(BaseCommand):
         parser.add_argument("refid")
         parser.add_argument("package_id")
         parser.add_argument("source_filename")
+        parser.add_argument("size", nargs="?", default=None)
 
     def handle(self, *args, **options):
         configuration = get_config(f"/{getenv('ENV')}/{getenv('APP_CONFIG_PATH')}")
@@ -36,9 +37,11 @@ class Command(BaseCommand):
         refid = options['refid']
         package_id = options['package_id']
         source_filename = options['source_filename']
+        size = int(0 if options['size'] is None else options['size'])
         try:
             title, uri, resource_title, resource_uri, undated_object, already_digitized, reel_box = client.get_package_data(refid)
-            size = s3_client.calculate_package_size(package_id)
+            if not size:
+                size = s3_client.calculate_package_size(package_id)
             Package.objects.create(
                 title=title,
                 uri=uri,

--- a/package_review/tests.py
+++ b/package_review/tests.py
@@ -185,11 +185,12 @@ class DiscoverPackagesCommandTests(TestCase):
         discover_packages.Command().handle(
             refid="123456789",
             package_id="528ecc4e-a116-4409-834e-18798125d473",
-            source_filename="R898/123456789.tar.gz")
+            source_filename="R898/123456789.tar.gz",
+            size="54321")
         mock_config.assert_called_once()
         mock_init.assert_called_once()
         mock_client.assert_called_once_with('s3', 'arn:aws:iam::123456789012:role/digitized-image-role')
-        mock_package_size.assert_called_once_with("528ecc4e-a116-4409-834e-18798125d473")
+        mock_package_size.assert_not_called()
         mock_message.assert_not_called()
         mock_package_data.assert_called_once()
         self.assertEqual(Package.objects.all().count(), 1)
@@ -197,6 +198,17 @@ class DiscoverPackagesCommandTests(TestCase):
         self.assertEqual(package.refid, "123456789")
         self.assertEqual(package.package_id, "528ecc4e-a116-4409-834e-18798125d473")
         self.assertEqual(package.source_filename, "R898/123456789.tar.gz")
+        self.assertEqual(package.size_bytes, 54321)
+
+        Package.objects.all().delete()
+
+        discover_packages.Command().handle(
+            refid="123456789",
+            package_id="528ecc4e-a116-4409-834e-18798125d473",
+            source_filename="R898/123456789.tar.gz",
+            size=None)
+        mock_package_size.assert_called_once_with("528ecc4e-a116-4409-834e-18798125d473")
+        package = Package.objects.all()[0]
         self.assertEqual(package.size_bytes, 1234)
 
     @mock_aws
@@ -211,7 +223,8 @@ class DiscoverPackagesCommandTests(TestCase):
         discover_packages.Command().handle(
             refid="123456789",
             package_id="528ecc4e-a116-4409-834e-18798125d473",
-            source_filename="R898/123456789.tar.gz")
+            source_filename="R898/123456789.tar.gz",
+            size=None)
         self.assertEqual(mock_message.call_count, 1)
 
 


### PR DESCRIPTION
Adds an optional argument for package size which, if sent, bypasses the need to calculate the package size.